### PR TITLE
Season class db

### DIFF
--- a/lib/season.rb
+++ b/lib/season.rb
@@ -1,0 +1,22 @@
+class Season
+
+  attr_reader :season_data, :season_id
+
+def initialize(season_id, games, game_teams)
+  @season_id = season_id
+  @raw_games = games
+  @raw_game_teams = game_teams
+  @season_data = create_season_data(@raw_games, @raw_game_teams)
+end
+  
+def create_season_data(raw_games, raw_game_teams)
+  season_games = raw_games.select{|game| game.season == @season_id}
+  season_game_ids = season_games.map{|game| game.game_id}.uniq
+  game_team_game_ids = raw_game_teams.map{|game_team| game_team.game_id}.uniq
+  matching_game_ids = season_game_ids & game_team_game_ids
+  season_game_teams = raw_game_teams.select{|game_team| matching_game_ids.include?(game_team.game_id)}
+  
+  season_data = {:games=>season_games, :game_teams=>season_game_teams}
+end
+
+end

--- a/spec/season_spec.rb
+++ b/spec/season_spec.rb
@@ -1,0 +1,38 @@
+require './spec/spec_helper'
+  RSpec.describe Season do
+    before(:each) do 
+    game_path = './data_mock/games.csv'
+    team_path = './data_mock/teams.csv'
+    game_teams_path = './data_mock/game_teams.csv'
+    
+    @locations = {
+      games: game_path,
+      teams: team_path,
+      game_teams: game_teams_path
+    }
+    
+    @stat_tracker = StatTracker.from_csv(@locations)
+    @season_1 = Season.new("20122013", @stat_tracker.games, @stat_tracker.game_teams)
+    @season_2 = Season.new("20132014", @stat_tracker.games, @stat_tracker.game_teams)
+  end
+
+  it "exists" do
+    expect(@season_1).to be_a(Season)
+  end
+
+  it "has attributes" do
+    expect(@season_1.season_id).to eq("20122013")
+    expect(@season_2.season_id).to eq("20132014")
+    expect(@season_1.season_data).to be_a(Hash)
+  end
+  
+  it "has the desired season data" do
+    expect(@season_1.season_data[:games]).to be_a(Array)
+    expect(@season_1.season_data[:games].length).to eq(14)
+    expect(@season_2.season_data[:games].length).to eq(5)
+    
+    expect(@season_1.season_data[:game_teams].length).to eq(10)
+  end
+
+    
+end


### PR DESCRIPTION
Hello! The season class has two readable attributes: @season_id, and @season_data. In the StatTracker class, I'm planning to make a hash containing all of the seasons. The keys will be the season_id, and the values will be the season_data. 

The season_data is a hash. I know, Dyson loves nested Hashes. I think it will make the data very easy to access though. 

There are only two keys; one is :games, and the other is :game_teams. The values will be arrays, one holds all of the game objects in that season, and the other holds all the game_teams for that season. This way we should have an easier time finding all the information about the games down the road, for things like the winningest coach method. 

Let me know if you have any concerns! I can change things before we merge.