### PR TITLE
create hash with season info within stat_tracker.rb with matching tests

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -4,13 +4,15 @@ class StatTracker
   attr_reader :data, 
               :teams, 
               :games, 
-              :game_teams
+              :game_teams,
+              :seasons_by_id
 
   def initialize(data)
     @data = data
     @teams = processed_teams_data(@data)
     @games = processed_games_data(@data)
     @game_teams = processed_game_teams_data(@data)
+    @seasons_by_id = processed_seasons_data
   end
   
   def self.from_csv(locations)
@@ -46,6 +48,15 @@ class StatTracker
       all_game_teams << GameTeam.new(row)
     end
     @game_teams = all_game_teams
+  end
+
+  def processed_seasons_data
+    all_seasons = Hash.new
+    @games.map{|game| game.season}.uniq.each do |season_id|
+      new_season = Season.new(season_id, @games, @game_teams)
+      all_seasons[season_id] = new_season.season_data
+    end
+    all_seasons
   end
 
   def percentage_home_wins

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe StatTracker do
       expect(@stat_tracker.processed_games_data(@locations)).to all(be_a(Game))
     end
 
+    it 'processed season data, creates hash of season info' do
+      expect(@stat_tracker.seasons_by_id).to be_a(Hash)
+      expect(@stat_tracker.seasons_by_id["20122013"][:games]).to all(be_a(Game))
+      expect(@stat_tracker.seasons_by_id["20122013"][:game_teams]).to all(be_a(GameTeam))
+    end
+
 
     it 'can parse data into a string of objects' do
       expect(@stat_tracker.games).to be_a(Array)


### PR DESCRIPTION
Creates a stat_tracker attribute which is a hash containing season info values accessible with a season id key.