### PR TITLE
reinstate deleted lowest_scoring_home_team method

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -210,6 +210,7 @@ class StatTracker
         return teams[team_id]
       end
     end
+  end
 
   def lowest_scoring_visitor
     team_names = Hash.new
@@ -221,6 +222,31 @@ class StatTracker
     end
     @game_teams.each do |game|
       if game.hoa == "away"
+        teams_total_games[game.team_id] += 1
+        teams_total_score[game.team_id] += game.goals.to_i
+      end
+    end
+    teams_total_games.each do |team_id, games|
+     teams_total_score.each do |team_id_score, goals|
+        if team_id_score == team_id
+          teams_goals_per_game[team_id] = (goals / games.to_f)
+        end
+      end
+    end
+    lowest_scoring_team = teams_goals_per_game.min_by { |team, goal_percentage| goal_percentage}[0]
+    team_names.find { |team_id, team_name| team_id == lowest_scoring_team}[1]
+  end
+
+  def lowest_scoring_home_team
+    team_names = Hash.new
+    teams_total_score = Hash.new(0)
+    teams_total_games = Hash.new(0)
+    teams_goals_per_game = Hash.new
+    @teams.each do |team|
+      team_names[team.team_id] = team.teamname
+    end
+    @game_teams.each do |game|
+      if game.hoa == "home"
         teams_total_games[game.team_id] += 1
         teams_total_score[game.team_id] += game.goals.to_i
       end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -140,11 +140,13 @@ RSpec.describe StatTracker do
     it "name of team that scored lowest average goals while away" do
       expect(@stat_tracker.lowest_scoring_visitor).to eq "San Jose Earthquakes"
     end
+  end
     
   describe 'offense' do
     it 'has #best_offense' do
       expect(@stat_tracker.best_offense).to eq "Reign FC"
     end
+  end
     
   describe 'lowest_scoring_home_team' do
     it "name of team that scored lowest average goals while home" do


### PR DESCRIPTION
My previous pull request deleted this method when I resolved the merge conflict.