### PR TITLE
Incredibly fast rspec db

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -2,22 +2,18 @@ class Game
   attr_reader :game_id,
               :season,
               :type,
-              :date_time,
               :away_team_id,
               :home_team_id,
               :away_goals,
-              :home_goals,
-              :venue
+              :home_goals
 
   def initialize(game_data)
     @game_id = game_data[:game_id]
     @season = game_data[:season]
     @type = game_data[:type]
-    @date_time = game_data[:date_time]
     @away_team_id = game_data[:away_team_id]
     @home_team_id = game_data[:home_team_id]
     @away_goals = game_data[:away_goals].to_i
     @home_goals = game_data[:home_goals].to_i
-    @venue = game_data[:venue]
   end
 end

--- a/lib/offensive_2.rb
+++ b/lib/offensive_2.rb
@@ -1,0 +1,18 @@
+def offensive(*away_or_home)
+  offense = Hash.new
+
+  applicable_games = @game_teams.select { |game_team|
+    away_or_home.include?(game_team.hoa)
+  }
+
+  @teams.each { |team|
+    this_teams_goals = applicable_games.select{ |game_team|
+      game_team.team_id == team.team_id
+      }.sum{|game_team| 
+        game_team.goals.to_f}
+    this_teams_games = applicable_games.select{|game_team| 
+      game_team.team_id == team.team_id}.length
+    offense[team.team_id] = this_teams_goals.to_f / this_teams_games.to_f
+  }
+  offense
+end

--- a/lib/offensive_2.rb
+++ b/lib/offensive_2.rb
@@ -14,7 +14,7 @@ module Offensive_2
           game_team.goals.to_f}
       this_teams_games = applicable_games.select{|game_team| 
         game_team.team_id == team.team_id}.length
-      offense[team.team_id] = this_teams_goals.to_f / this_teams_games.to_f
+      offense[team.team_id] = (this_teams_goals / this_teams_games.to_f)
     }
     offense
   end

--- a/lib/offensive_2.rb
+++ b/lib/offensive_2.rb
@@ -1,18 +1,22 @@
-def offensive(*away_or_home)
-  offense = Hash.new
+module Offensive_2
 
-  applicable_games = @game_teams.select { |game_team|
-    away_or_home.include?(game_team.hoa)
-  }
+  def offensive_2(*away_or_home)
+    offense = Hash.new
 
-  @teams.each { |team|
-    this_teams_goals = applicable_games.select{ |game_team|
-      game_team.team_id == team.team_id
-      }.sum{|game_team| 
-        game_team.goals.to_f}
-    this_teams_games = applicable_games.select{|game_team| 
-      game_team.team_id == team.team_id}.length
-    offense[team.team_id] = this_teams_goals.to_f / this_teams_games.to_f
-  }
-  offense
+    applicable_games = @game_teams.select { |game_team|
+      away_or_home.include?(game_team.hoa)
+    }
+
+    @teams.each { |team|
+      this_teams_goals = applicable_games.select{ |game_team|
+        game_team.team_id == team.team_id
+        }.sum{|game_team| 
+          game_team.goals.to_f}
+      this_teams_games = applicable_games.select{|game_team| 
+        game_team.team_id == team.team_id}.length
+      offense[team.team_id] = this_teams_goals.to_f / this_teams_games.to_f
+    }
+    offense
+  end
+
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -188,7 +188,7 @@ class StatTracker < StatisticsGenerator
 
 
   def best_offense 
-    best_offense = offensive.max_by {|id,avg_goals| avg_goals} 
+    best_offense = offensive("away", "home").max_by {|id,avg_goals| avg_goals} 
     best_team = @teams.find {|team| team.team_id == best_offense.first}.teamname
   end
 

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -8,11 +8,13 @@ require_relative 'team_accuracy'
 require_relative 'offensive'
 require_relative 'tackle_counter'
 require_relative 'statistics_generator'
+require_relative 'offensive_2'
 
 class StatTracker < StatisticsGenerator
   include TeamAccuracy
   include Offensive
   include TackleCounter
+  include Offensive_2
 
   def initialize(data)
     super(data)
@@ -188,7 +190,7 @@ class StatTracker < StatisticsGenerator
 
 
   def best_offense 
-    best_offense = offensive("away", "home").max_by {|id,avg_goals| avg_goals} 
+    best_offense = offensive_2("away", "home").max_by {|id,avg_goals| avg_goals} 
     best_team = @teams.find {|team| team.team_id == best_offense.first}.teamname
   end
 

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -14,12 +14,6 @@ class StatTracker < StatisticsGenerator
   include Offensive
   include TackleCounter
 
-  attr_reader :data, 
-              :teams, 
-              :games, 
-              :game_teams,
-              :seasons_by_id
-
   def initialize(data)
     super(data)
   end

--- a/lib/statistics_generator.rb
+++ b/lib/statistics_generator.rb
@@ -26,8 +26,8 @@ class StatisticsGenerator
     end
     new(new_locations)
   end
-
-  def processed_teams_data(locations)
+  
+  def processed_teams_data(locations) :teams
     all_teams = []
     teams = @data[:teams]
     teams.each do |row|

--- a/lib/team_accuracy.rb
+++ b/lib/team_accuracy.rb
@@ -1,25 +1,17 @@
 module TeamAccuracy
 
   def find_accuracy_ratios(season_id)
-    team_scores = Hash.new(0)
-      team_shots = Hash.new(0)
-      team_games = {}
-      team_ids = @seasons_by_id[season_id][:team_ids]
-      team_ids.each {|team_id| team_games[team_id] = []}
-      @seasons_by_id[season_id][:game_teams].each do |game|
-        team_games[game.team_id] << game
-      end
-      team_games.each do |team, games|
-        games.each do |game|
-          team_scores[team] += game.goals.to_i
-          team_shots[team] += game.shots.to_i
-        end
-      end
-      ratios = Hash.new(0.0)
-      team_ids.each do |team_id|
-        ratios[team_id] = (team_scores[team_id].to_f / team_shots[team_id].to_f)
-      end
-      return ratios
+    accuracy_by_team = Hash.new
+
+    @seasons_by_id[season_id][:team_ids].each { |team_id|
+    this_teams_goals = 0.0
+    this_teams_shots = 0.0
+    this_teams_games = @seasons_by_id[season_id][:game_teams].select{|game_team| game_team.team_id == team_id}
+    this_teams_goals += this_teams_games.sum{|game| game.goals.to_f}
+    this_teams_shots += this_teams_games.sum{|game| game.shots.to_f}
+    accuracy_by_team[team_id] = (this_teams_goals / this_teams_shots) 
+    }
+    accuracy_by_team
   end
 
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -2,45 +2,24 @@ require_relative 'spec_helper'
 require './lib/stat_tracker'
 
 RSpec.describe StatTracker do
-  before(:each) do 
+  before(:all) do
     game_path = './data/games.csv'
     team_path = './data/teams.csv'
     game_teams_path = './data/game_teams.csv'
-    @locations = {
+
+    locations = {
       games: game_path,
       teams: team_path,
       game_teams: game_teams_path
     }
-    @stat_tracker = StatTracker.from_csv(@locations)
+
+    @stat_tracker = StatTracker.from_csv(locations)
   end
   
   describe 'initialize' do
     it 'exists' do
       expect(@stat_tracker).is_a?(StatisticsGenerator)
       expect(@stat_tracker).to be_an_instance_of StatTracker
-    end
-    
-    it 'processed team data, retrieves data from teams' do
-      expect(@stat_tracker.processed_teams_data(@locations)).to all(be_a(Team))
-    end
-
-    it 'processed team data, retrieves data from teams' do
-      expect(@stat_tracker.processed_games_data(@locations)).to all(be_a(Game))
-    end
-
-    it 'processed season data, creates hash of season info' do
-      expect(@stat_tracker.seasons_by_id).to be_a(Hash)
-      expect(@stat_tracker.seasons_by_id["20122013"][:games]).to all(be_a(Game))
-      expect(@stat_tracker.seasons_by_id["20122013"][:game_teams]).to all(be_a(GameTeam))
-    end
-
-    it 'can parse data into a string of objects' do
-      expect(@stat_tracker.games).to be_a(Array)
-      expect(@stat_tracker.games).to all(be_a(Game))
-    end
-
-    it 'processed team data, retrieves data from teams' do
-      expect(@stat_tracker.processed_game_teams_data(@locations)).to all(be_a(GameTeam))
     end
   end
 

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -15,80 +15,80 @@ RSpec.describe StatTracker do
   end
   
   describe 'initialize' do
-    xit 'exists' do
+    it 'exists' do
       expect(@stat_tracker).is_a?(StatisticsGenerator)
       expect(@stat_tracker).to be_an_instance_of StatTracker
     end
     
-    xit 'processed team data, retrieves data from teams' do
+    it 'processed team data, retrieves data from teams' do
       expect(@stat_tracker.processed_teams_data(@locations)).to all(be_a(Team))
     end
 
-    xit 'processed team data, retrieves data from teams' do
+    it 'processed team data, retrieves data from teams' do
       expect(@stat_tracker.processed_games_data(@locations)).to all(be_a(Game))
     end
 
-    xit 'processed season data, creates hash of season info' do
+    it 'processed season data, creates hash of season info' do
       expect(@stat_tracker.seasons_by_id).to be_a(Hash)
       expect(@stat_tracker.seasons_by_id["20122013"][:games]).to all(be_a(Game))
       expect(@stat_tracker.seasons_by_id["20122013"][:game_teams]).to all(be_a(GameTeam))
     end
 
-    xit 'can parse data into a string of objects' do
+    it 'can parse data into a string of objects' do
       expect(@stat_tracker.games).to be_a(Array)
       expect(@stat_tracker.games).to all(be_a(Game))
     end
 
-    xit 'processed team data, retrieves data from teams' do
+    it 'processed team data, retrieves data from teams' do
       expect(@stat_tracker.processed_game_teams_data(@locations)).to all(be_a(GameTeam))
     end
   end
 
   describe 'percentage_home_wins' do
-    xit 'float of home teams that have won games' do
+    it 'float of home teams that have won games' do
       expect(@stat_tracker.percentage_home_wins).to eq(0.44)
     end 
   end  
 
   describe 'percentage_visitor_wins' do
-    xit 'float of visitor teams that have won games' do
+    it 'float of visitor teams that have won games' do
       expect(@stat_tracker.percentage_visitor_wins).to eq(0.36)
     end 
   end  
 
   describe 'percentage_ties' do
-    xit 'float of teams that tied games' do
+    it 'float of teams that tied games' do
       expect(@stat_tracker.percentage_ties).to eq(0.20)
     end 
   end  
 
   describe '#highest_total_score' do
-    xit 'sum of scores in highest scoring game' do
+    it 'sum of scores in highest scoring game' do
       expect(@stat_tracker.highest_total_score).to eq(11)
     end
   end
 
   describe '#average_goals_per_game' do
-    xit 'take average of goals scored in a game across all seasons, both home and away goals' do
+    it 'take average of goals scored in a game across all seasons, both home and away goals' do
     expect(@stat_tracker.average_goals_per_game).to eq(4.22)
     end
   end
   
   describe '#lowest_total_score' do
-    xit 'sum of scores in lowest scoring game' do
+    it 'sum of scores in lowest scoring game' do
       expect(@stat_tracker.lowest_total_score).to eq(0)
     end
   end
 
   describe '#count_of_teams' do
-    xit '#count_of_teams' do
+    it '#count_of_teams' do
       expect(@stat_tracker.count_of_teams).to eq 32
     end
   end
 
 
   describe '#winningest_coach' do
-    xit 'coach with best win percentage for each season' do
+    it 'coach with best win percentage for each season' do
       expect(@stat_tracker.winningest_coach("20122013")).to eq "Dan Lacroix"
       expect(@stat_tracker.winningest_coach("20132014")).to eq "Claude Julien"
       expect(@stat_tracker.winningest_coach("20142015")).to eq "Alain Vigneault"
@@ -99,35 +99,35 @@ RSpec.describe StatTracker do
    end
    
   describe '#count_of_games_by_season' do
-    xit '#count_of_games_by_season' do
+    it '#count_of_games_by_season' do
       expect(@stat_tracker.count_of_games_by_season["20122013"]).to eq(806)
       expect(@stat_tracker.seasons_by_id["20122013"][:game_teams].length).to eq(1612)
     end
   end
 
   describe '#average_goals_by_season' do
-    xit '#average_goals_by_season' do
+    it '#average_goals_by_season' do
       expect(@stat_tracker.average_goals_by_season["20122013"]).to eq(4.12)
       expect(@stat_tracker.average_goals_by_season["20162017"]).to eq(4.23)
     end
   end
 
   describe '#most_accurate team' do
-    xit "#most_accurate_team" do
+    it "#most_accurate_team" do
       expect(@stat_tracker.most_accurate_team("20132014")).to eq "Real Salt Lake"
       expect(@stat_tracker.most_accurate_team("20142015")).to eq "Toronto FC"
     end
   end
 
   describe '#least_accurate_team' do
-    xit '#least_accurate_team' do
+    it '#least_accurate_team' do
       expect(@stat_tracker.least_accurate_team("20132014")).to eq "New York City FC"
       expect(@stat_tracker.least_accurate_team("20142015")).to eq "Columbus Crew SC"
     end
   end
   
   describe '#worst_coach' do
-    xit 'coach with worst win percentage for each season' do
+    it 'coach with worst win percentage for each season' do
     expect(@stat_tracker.worst_coach("20122013")).to eq "Martin Raymond"
     expect(@stat_tracker.worst_coach("20132014")).to eq "Peter Laviolette"
     expect(@stat_tracker.worst_coach("20142015")).to eq("Craig MacTavish").or(eq("Ted Nolan"))
@@ -138,7 +138,7 @@ RSpec.describe StatTracker do
   end
 
   describe '#lowest_scoring_visitor' do
-    xit "name of team that scored lowest average goals while away" do
+    it "name of team that scored lowest average goals while away" do
       expect(@stat_tracker.lowest_scoring_visitor).to eq "San Jose Earthquakes"
     end
   end
@@ -148,32 +148,32 @@ RSpec.describe StatTracker do
       expect(@stat_tracker.best_offense).to eq "Reign FC"
     end
     
-    xit "#worst_offense" do
+    it "#worst_offense" do
       expect(@stat_tracker.worst_offense).to eq "Utah Royals FC"
     end
   end
     
   describe 'lowest_scoring_home_team' do
-    xit "name of team that scored lowest average goals while home" do
+    it "name of team that scored lowest average goals while home" do
       expect(@stat_tracker.lowest_scoring_home_team).to eq "Utah Royals FC"
     end
   
-    xit "#highest_scoring_visitor" do
+    it "#highest_scoring_visitor" do
     expect(@stat_tracker.highest_scoring_visitor).to eq "FC Dallas"
     end
 
-    xit "#highest_scoring_home_team" do
+    it "#highest_scoring_home_team" do
     expect(@stat_tracker.highest_scoring_home_team).to eq "Reign FC"
     end
   end
 
   describe "Tackles" do
-    xit "#most_tackles" do
+    it "#most_tackles" do
       expect(@stat_tracker.most_tackles("20132014")).to eq "FC Cincinnati"
       expect(@stat_tracker.most_tackles("20142015")).to eq "Seattle Sounders FC"
     end
 
-    xit "#fewest_tackles" do
+    it "#fewest_tackles" do
       expect(@stat_tracker.fewest_tackles("20132014")).to eq "Atlanta United"
       expect(@stat_tracker.fewest_tackles("20142015")).to eq "Orlando City SC"
     end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe StatTracker do
    end
    
   describe '#count_of_games_by_season' do
-    xit '#count_of_games_by_season' do
+    it '#count_of_games_by_season' do
       expect(@stat_tracker.count_of_games_by_season["20122013"]).to eq(806)
       expect(@stat_tracker.seasons_by_id["20122013"][:game_teams].length).to eq(1612)
     end
@@ -168,12 +168,12 @@ RSpec.describe StatTracker do
   end
 
   describe "Tackles" do
-    xit "#most_tackles" do
+    it "#most_tackles" do
       expect(@stat_tracker.most_tackles("20132014")).to eq "FC Cincinnati"
       expect(@stat_tracker.most_tackles("20142015")).to eq "Seattle Sounders FC"
     end
 
-    xit "#fewest_tackles" do
+    it "#fewest_tackles" do
       expect(@stat_tracker.fewest_tackles("20132014")).to eq "Atlanta United"
       expect(@stat_tracker.fewest_tackles("20142015")).to eq "Orlando City SC"
     end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -15,80 +15,80 @@ RSpec.describe StatTracker do
   end
   
   describe 'initialize' do
-    it 'exists' do
+    xit 'exists' do
       expect(@stat_tracker).is_a?(StatisticsGenerator)
       expect(@stat_tracker).to be_an_instance_of StatTracker
     end
     
-    it 'processed team data, retrieves data from teams' do
+    xit 'processed team data, retrieves data from teams' do
       expect(@stat_tracker.processed_teams_data(@locations)).to all(be_a(Team))
     end
 
-    it 'processed team data, retrieves data from teams' do
+    xit 'processed team data, retrieves data from teams' do
       expect(@stat_tracker.processed_games_data(@locations)).to all(be_a(Game))
     end
 
-    it 'processed season data, creates hash of season info' do
+    xit 'processed season data, creates hash of season info' do
       expect(@stat_tracker.seasons_by_id).to be_a(Hash)
       expect(@stat_tracker.seasons_by_id["20122013"][:games]).to all(be_a(Game))
       expect(@stat_tracker.seasons_by_id["20122013"][:game_teams]).to all(be_a(GameTeam))
     end
 
-    it 'can parse data into a string of objects' do
+    xit 'can parse data into a string of objects' do
       expect(@stat_tracker.games).to be_a(Array)
       expect(@stat_tracker.games).to all(be_a(Game))
     end
 
-    it 'processed team data, retrieves data from teams' do
+    xit 'processed team data, retrieves data from teams' do
       expect(@stat_tracker.processed_game_teams_data(@locations)).to all(be_a(GameTeam))
     end
   end
 
   describe 'percentage_home_wins' do
-    it 'float of home teams that have won games' do
+    xit 'float of home teams that have won games' do
       expect(@stat_tracker.percentage_home_wins).to eq(0.44)
     end 
   end  
 
   describe 'percentage_visitor_wins' do
-    it 'float of visitor teams that have won games' do
+    xit 'float of visitor teams that have won games' do
       expect(@stat_tracker.percentage_visitor_wins).to eq(0.36)
     end 
   end  
 
   describe 'percentage_ties' do
-    it 'float of teams that tied games' do
+    xit 'float of teams that tied games' do
       expect(@stat_tracker.percentage_ties).to eq(0.20)
     end 
   end  
 
   describe '#highest_total_score' do
-    it 'sum of scores in highest scoring game' do
+    xit 'sum of scores in highest scoring game' do
       expect(@stat_tracker.highest_total_score).to eq(11)
     end
   end
 
   describe '#average_goals_per_game' do
-    it 'take average of goals scored in a game across all seasons, both home and away goals' do
+    xit 'take average of goals scored in a game across all seasons, both home and away goals' do
     expect(@stat_tracker.average_goals_per_game).to eq(4.22)
     end
   end
   
   describe '#lowest_total_score' do
-    it 'sum of scores in lowest scoring game' do
+    xit 'sum of scores in lowest scoring game' do
       expect(@stat_tracker.lowest_total_score).to eq(0)
     end
   end
 
   describe '#count_of_teams' do
-    it '#count_of_teams' do
+    xit '#count_of_teams' do
       expect(@stat_tracker.count_of_teams).to eq 32
     end
   end
 
 
   describe '#winningest_coach' do
-    it 'coach with best win percentage for each season' do
+    xit 'coach with best win percentage for each season' do
       expect(@stat_tracker.winningest_coach("20122013")).to eq "Dan Lacroix"
       expect(@stat_tracker.winningest_coach("20132014")).to eq "Claude Julien"
       expect(@stat_tracker.winningest_coach("20142015")).to eq "Alain Vigneault"
@@ -99,35 +99,35 @@ RSpec.describe StatTracker do
    end
    
   describe '#count_of_games_by_season' do
-    it '#count_of_games_by_season' do
+    xit '#count_of_games_by_season' do
       expect(@stat_tracker.count_of_games_by_season["20122013"]).to eq(806)
       expect(@stat_tracker.seasons_by_id["20122013"][:game_teams].length).to eq(1612)
     end
   end
 
   describe '#average_goals_by_season' do
-    it '#average_goals_by_season' do
+    xit '#average_goals_by_season' do
       expect(@stat_tracker.average_goals_by_season["20122013"]).to eq(4.12)
       expect(@stat_tracker.average_goals_by_season["20162017"]).to eq(4.23)
     end
   end
 
   describe '#most_accurate team' do
-    it "#most_accurate_team" do
+    xit "#most_accurate_team" do
       expect(@stat_tracker.most_accurate_team("20132014")).to eq "Real Salt Lake"
       expect(@stat_tracker.most_accurate_team("20142015")).to eq "Toronto FC"
     end
   end
 
   describe '#least_accurate_team' do
-    it '#least_accurate_team' do
+    xit '#least_accurate_team' do
       expect(@stat_tracker.least_accurate_team("20132014")).to eq "New York City FC"
       expect(@stat_tracker.least_accurate_team("20142015")).to eq "Columbus Crew SC"
     end
   end
   
   describe '#worst_coach' do
-    it 'coach with worst win percentage for each season' do
+    xit 'coach with worst win percentage for each season' do
     expect(@stat_tracker.worst_coach("20122013")).to eq "Martin Raymond"
     expect(@stat_tracker.worst_coach("20132014")).to eq "Peter Laviolette"
     expect(@stat_tracker.worst_coach("20142015")).to eq("Craig MacTavish").or(eq("Ted Nolan"))
@@ -138,7 +138,7 @@ RSpec.describe StatTracker do
   end
 
   describe '#lowest_scoring_visitor' do
-    it "name of team that scored lowest average goals while away" do
+    xit "name of team that scored lowest average goals while away" do
       expect(@stat_tracker.lowest_scoring_visitor).to eq "San Jose Earthquakes"
     end
   end
@@ -148,32 +148,32 @@ RSpec.describe StatTracker do
       expect(@stat_tracker.best_offense).to eq "Reign FC"
     end
     
-    it "#worst_offense" do
+    xit "#worst_offense" do
       expect(@stat_tracker.worst_offense).to eq "Utah Royals FC"
     end
   end
     
   describe 'lowest_scoring_home_team' do
-    it "name of team that scored lowest average goals while home" do
+    xit "name of team that scored lowest average goals while home" do
       expect(@stat_tracker.lowest_scoring_home_team).to eq "Utah Royals FC"
     end
   
-    it "#highest_scoring_visitor" do
+    xit "#highest_scoring_visitor" do
     expect(@stat_tracker.highest_scoring_visitor).to eq "FC Dallas"
     end
 
-    it "#highest_scoring_home_team" do
+    xit "#highest_scoring_home_team" do
     expect(@stat_tracker.highest_scoring_home_team).to eq "Reign FC"
     end
   end
 
   describe "Tackles" do
-    it "#most_tackles" do
+    xit "#most_tackles" do
       expect(@stat_tracker.most_tackles("20132014")).to eq "FC Cincinnati"
       expect(@stat_tracker.most_tackles("20142015")).to eq "Seattle Sounders FC"
     end
 
-    it "#fewest_tackles" do
+    xit "#fewest_tackles" do
       expect(@stat_tracker.fewest_tackles("20132014")).to eq "Atlanta United"
       expect(@stat_tracker.fewest_tackles("20142015")).to eq "Orlando City SC"
     end


### PR DESCRIPTION
Several of our tests were being repeated in in the statistics_generator_spec and stat_tracker_spec files. By deleting the redundant 'it' blocks from stat_tracker, we can allow before(:all) to be run at the top of the spec file instead of before(:each).
This allows @stat_tracker to be instantiated only once. This cuts our test time from almost a minute down to under three seconds.